### PR TITLE
feat:add request reload feature and subscribe feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastcampus/fastcache",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastcampus/fastcache",
-      "version": "0.0.9",
+      "version": "0.0.11",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^26.0.19",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@fastcampus/fastcache",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "fast and simple cache using redis",
-  "url": "https://github.com/fastcampus/fastcache",
-  "repository": "https://github.com/fastcampus/fastcache",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/day1co/fastcache.git"
+  },
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
(fastcampus/fastbus를 이동한 PR입니다.)
## 개요
Fastbus를 Cloud pub/sub으로 변경하면서 기존에 cache reload를 위한 redis publish 기능을 Fastcache로 이동하기 위함

Fastbus에서 cache reload를 위해 broadcast publish를 사용하는 방법은 아래와 같습니다.

<img width="574" alt="Screen Shot 2022-01-28 at 11 05 17" src="https://user-images.githubusercontent.com/47456161/151474504-cd150a7e-a1e0-464e-87bf-64e87fddcf3d.png">


1. FASTCAMPUS 서버 중 하나의 인스턴스에서 redis에게 SYSTEM_RELOAD 채널로 reload 메시지를 publish 합니다.
reload 메시지를 publis 하는 케이스는 아래와 같습니다.
a. banner나 menu가 create, update 되는 경우
b. FASTCAMPUS 서버의 reload URL로 get 요청을 했을 경우
```javascript
const createBanner = async ({ data }) => {
  const result = await bannerDao.insert(data);
  // broadcast publish
  bus.publish(BusTopic.SYSTEM_RELOAD, 'BANNER', true);
  return result;
};
```


2. redis는 subscribe하고 있는 subscriber들에게 메시지를 publish 합니다.

3. FASTCAMPUS는 SYSTEM_RELOAD라는 채널을 subscribe 하고 있으므로 redis가 보낸 메시지를 받게되고 local cache를 update 합니다.
(패스트캠퍼스에서는 subscribe의 listener에 redis cahce를 invalidate하는 로직을 넣어서 redis cache에 저장된 payment method list를 제거하기도 합니다.)

[FASTCAMPUS에 subscribe 하고 있는 부분](https://github.com/fastcampus/fastcampus/blob/0c71806c6a3f5f5e39cd3d3589d12b128765c151/fastcampus/index.js#L45-L46)

## 설명
필요한 기능

1. redis publish
2. redis subscribe
[fastbus에서는 psubscribe](https://github.com/fastcampus/fastbus/blob/05baa326f50f7fc2b494425cb6ae5688e1f5ae46/src/fast-bus.ts#L74-L105)([psubscribe란](https://redis.io/commands/psubscribe) 패턴이 동일한 모든 channel을 구독하는 subscribe 함수)를 사용해서 broadcast publish와 message queue 두 기능 모두를 지원했습니다.


## 변경되는 부분
기존의 Fastbus에서는 redis pub/sub을 이용하여 개별 메시지를 queue에 넣고
reloadChannel의 prefix default 값은 bus:0: 입니다.

* broadcast
* onReload
* subscribe
* unsubscribe
메소드를 추가했습니다.

## 사용
* 구독자 추가: `bus.subscribe('SYSTEM_RELOAD')` (기존의 fastbus와 다르게 subscribe 등록을 해당 클래스 생성시에 하지 않기 때문에,사용하는 server를 기동할때 subscribe 등록을 해주어야 합니다.)
* 리로드 브로드캐스트: `bus.broadcast('BANNER')`
* 리스너 추가: `bus.onReload('BANNER', (target) => console.log('target'))`