### PR TITLE
add more log to confirm opts from anywhere

### DIFF
--- a/src/FastCache.ts
+++ b/src/FastCache.ts
@@ -54,8 +54,9 @@ export class FastCache {
 
   private constructor(opts?: FastCacheOpts) {
     this.logger = LoggerFactory.getLogger('fastcache');
+    this.logger.debug('opts: %o', opts);
     this.client = opts?.createRedisClient ? opts?.createRedisClient(opts?.redis) : new IORedis(opts?.redis);
-    this.logger.debug(`connect redis: ${opts?.redis?.host}:${opts?.redis?.port}/${opts?.redis?.db}`);
+    this.logger.debug(`connected redis: ${opts?.redis?.host}:${opts?.redis?.port}/${opts?.redis?.db}`);
     this.prefix = opts?.prefix ?? '';
     this.ttl = opts?.ttl ?? 60 * 5; // 5min
   }


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

Redstone v4 를 바탕으로 올라가는 서비스 중 opts 없이 Fastcache 인스턴스를 호출하는 의심 상황이 있어 로그 한줄 더 추가해 봅니다.

## 무엇을 어떻게 변경했나요?

thanos in run 서비스에서 다량의 ioredis 예외 로그가 발생하고 있는 상황에 서버 정보 없시 생성시도하는 로그를 확보하려 합니다.

![image](https://user-images.githubusercontent.com/906974/206653386-0aced7f4-7636-4aae-87aa-0428373745ba.png)

