### PR TITLE
reinforce withCache method with test case [CMSPF-337]

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ await map.get('one');
 await map.getAll(['one', 'two']);
 // [ first, second ]
 ```
+## withCache in real world
+
+checkout example.ts
+
+```js
+function getDataByIdWithCache(id) {
+  return this.cacheService.withCache(`course@${id}`, () => {
+    return this.getDataById(id);
+  });
+}
+
+async function getDataById(id) {
+  const course = await this.redstoneDataService.getDataById(id);
+  if (!course || !course.id) {
+    logger.warn('unavailable course requested %s', id);
+    return {};
+  }
+  return course;
+}
+```
 
 ## Contributing
 

--- a/example/example.ts
+++ b/example/example.ts
@@ -1,7 +1,17 @@
+import { setTimeout } from 'node:timers/promises';
+
 import { FastCache } from '../src';
+
+const getData = async (id: number) => {
+  await setTimeout(10);
+  console.log('should called once');
+  return `${id}:with data`;
+};
 
 const main = async () => {
   const cache = FastCache.create({ redis: { host: '127.0.0.1', port: 6379, db: 0 } });
+
+  console.log('== start of main ==');
 
   await cache.set('foo', 'hello');
   console.log(await cache.get('foo'));
@@ -25,7 +35,26 @@ const main = async () => {
   console.log(await map.getAll(['one', 'two']));
   // [ first, second ]
 
+  await cache.withCache('page@10', async () => {
+    const result = await getData(10);
+    console.log('retrieved:', result);
+
+    return result;
+  });
+
+  await setTimeout(1000);
+
+  const result = await cache.withCache('page@10', () => {
+    return getData(10);
+  });
+
+  console.log('cached:', result);
+  // clear cache for test
+  // await cache.remove('page@10');
+
   cache.destroy();
+
+  console.log('== end of main ==');
 };
 
 main().then(console.info).catch(console.error);

--- a/src/FastCache.spec.ts
+++ b/src/FastCache.spec.ts
@@ -202,9 +202,32 @@ describe('FastCache', () => {
     });
   });
 
-  describe.skip('withCache', () => {
-    test('should be tested', (done) => {
-      done();
+  describe('withCache', () => {
+    test('should be set after next tick', (done) => {
+      const a = { foo: 100 };
+      cache.withCache('foo', () => {
+        return new Promise((resolve) => {
+          resolve(a);
+        });
+      });
+      setTimeout(async () => {
+        const foo = await cache.get('foo');
+        expect(foo).toEqual(JSON.stringify(a));
+        done();
+      }, 10);
+    });
+    test('should be failed to verify for wrong value', (done) => {
+      const b = { bar: 100 };
+      cache.withCache('foo', () => {
+        return new Promise((resolve) => {
+          resolve(b);
+        });
+      });
+      setTimeout(() => {
+        const foo = cache.get('foo');
+        expect(foo).not.toEqual('wrong string');
+        done();
+      }, 10);
     });
   });
 

--- a/src/FastCache.ts
+++ b/src/FastCache.ts
@@ -180,12 +180,12 @@ export class FastCache {
 
   //---------------------------------------------------------
 
-  public async withCache(key: string, executor: Promise<any>): Promise<any> {
+  public async withCache(key: string, executor: () => Promise<unknown>): Promise<unknown> {
     const cached = await this.get(key);
     if (cached) {
       return this.deserialize(cached);
     }
-    return executor
+    return executor()
       .then((result) => {
         setImmediate(() =>
           this.set(key, this.serialize(result))


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)

아직 withCache 를 사용하는 곳이 없어 스펙을 변경하려 합니다.

executor 가 Promise 본문이어서 무조건 then() 이전에 실행이 되어야 함 → 데이터를 패치하는 함수인 경우 경우에 따라 실행되지 말아야 함 ← 그 값을 cache 에서 가져오도록 하는게 이 함수의 목적.

- executor 가 함수형이 되면 cache 에 key 가 데이터를 가지고 있을지 구분하는 과정 이후 lazy 하게 실행이 가능함
- 필요한 파라미터는 closure 를 통해 전달

## 무엇을 어떻게 변경했나요?

- executor 타입을 Promise 에서 Function<Promise> 로 변경합니다.
- 예제 코드와 테스트 케이스를 추가합니다.

## 어떻게 테스트 하셨나요?

추가한 예제 코드를 참고해주세요. 
스모크 테스트

