### PR TITLE
fix: withCache function debugging

### DIFF
--- a/src/FastCache.ts
+++ b/src/FastCache.ts
@@ -190,7 +190,7 @@ export class FastCache {
       .then((result) => {
         setImmediate(() =>
           this.set(key, this.serialize(result))
-            .then((result) => this.logger.debug('set ok: %o', result))
+            .then(() => this.logger.debug('set ok: %o', result))
             .catch((err) => this.logger.error('set error: %o', err))
         );
         return result;
@@ -198,7 +198,7 @@ export class FastCache {
       .catch((err) => {
         setImmediate(() =>
           this.remove(key)
-            .then((result) => this.logger.debug('set ok: %o', result))
+            .then(() => this.logger.debug('key removed ok: %s', key))
             .catch((err) => this.logger.error('set error: %o', err))
         );
         throw err;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
this.set, this.remove의 resolve는 void인데 그 값을 디버깅하고 있음
<img width="531" alt="Screenshot 2023-04-13 at 4 01 26 PM" src="https://user-images.githubusercontent.com/63729090/231679477-5559bd8d-4c5b-4d65-9722-ea53a6a22aed.png">

## 무엇을 어떻게 변경했나요?
withCache 메서드의 인자인 executor의 resolve값을 디버깅하도록 변경
.catch() 절에서도 .then() 절과 똑같은 메세지의 로그를 남기고 있어, 로직에 맞게 로그 메세지 수정

근데 캐시 키 타입이 any라서.. 로그를 `key removed ok: %s, key` 라고 받는게 맞는건가 싶습니다

## 어떻게 테스트 하셨나요?
스모크테스트

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="531" alt="Screenshot 2023-04-13 at 4 03 20 PM" src="https://user-images.githubusercontent.com/63729090/231679883-fbdb29a1-27e6-4872-8ae0-9f9dbed3fe65.png">
