### PR TITLE
refactor: this.set() in withCache method to log key name

### DIFF
--- a/src/FastCache.ts
+++ b/src/FastCache.ts
@@ -190,7 +190,7 @@ export class FastCache {
       .then((result) => {
         setImmediate(() =>
           this.set(key, this.serialize(result))
-            .then(() => this.logger.debug('set ok: %o', result))
+            .then(() => this.logger.debug('key set ok: %s', key))
             .catch((err) => this.logger.error('set error: %o', err))
         );
         return result;


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
https://github.com/day1co/fastcache/pull/19#issuecomment-1507824453

## 무엇을 어떻게 변경했나요?
withCache 메서드의 this.set() 동작에서 캐시 key를 로깅하도록 한다.

## 어떻게 테스트 하셨나요?
스모크테스트

## 코드의 실행결과를 볼 수 있는 로그나 이미지가 있다면 첨부해주세요.
<img width="531" alt="Screenshot 2023-04-14 at 12 07 36 PM" src="https://user-images.githubusercontent.com/63729090/231931467-a62633dd-8b87-45dd-abc5-d32646f6a966.png">
