### PR TITLE
refactor: flush method to unlink keys even under 50 count

### DIFF
--- a/src/FastCache.spec.ts
+++ b/src/FastCache.spec.ts
@@ -241,4 +241,33 @@ describe('FastCache', () => {
       }
     });
   });
+
+  describe('flush', () => {
+    test('unlink every key over 50 count', (done) => {
+      const testKeys: string[] = [];
+      for (let i = 0; i < 60; i++) {
+        testKeys.push(`test${i}`);
+        client.set(`test${i}`, 'hello');
+      }
+      cache.flush('test*').then(() => {
+        cache.getAll(testKeys).then((values) => {
+          expect(values.every((value) => value === null)).toEqual(true);
+          done();
+        });
+      });
+    });
+    test('unlink every key within 50 count', (done) => {
+      const testKeys: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        testKeys.push(`test${i}`);
+        client.set(`test${i}`, 'hello');
+      }
+      cache.flush('test*').then(() => {
+        cache.getAll(testKeys).then((values) => {
+          expect(values.every((value) => value === null)).toEqual(true);
+          done();
+        });
+      });
+    });
+  });
 });

--- a/src/FastCache.ts
+++ b/src/FastCache.ts
@@ -99,8 +99,8 @@ export class FastCache {
     await this.client.del(keys);
   }
 
-  public async flush(pattern = '*'): Promise<void> {
-    if (pattern === '*') {
+  public async flush(pattern: string): Promise<void> {
+    if (pattern === '*******') {
       await this.client.flushdb('ASYNC');
       return;
     }

--- a/src/FastCache.ts
+++ b/src/FastCache.ts
@@ -104,14 +104,16 @@ export class FastCache {
       await this.client.flushdb('ASYNC');
       return;
     }
-    // XXX: partial flush
-    let [cursor, keys] = await this.client.scan('0', 'MATCH', pattern, 'COUNT', 50);
-    while (cursor !== '0') {
+
+    let cursor = '0';
+    let keys: string[] = [];
+
+    do {
+      [cursor, keys] = await this.client.scan('0', 'MATCH', pattern, 'COUNT', 50);
       if (keys && keys.length) {
         await this.client.unlink(keys);
       }
-      [cursor, keys] = await this.client.scan(cursor, 'MATCH', pattern, 'COUNT', 50);
-    }
+    } while (cursor !== '0');
   }
 
   //---------------------------------------------------------


### PR DESCRIPTION
## PR 의 종류는 어떤 것인가요?

- [x] 버그 수정
- [x] 리팩토링

## 수정이 필요하게된 이유가 무엇인가요? (Jira 이슈가 있다면 링크를 연결해주세요)
cache.flush 기능이 필요하다.
ex ) pages/slug* 패턴에 해당하는 캐시 키를 모두 제거해야 한다.
하지만 현재 기능으로서는 만일 pages/slug* 패턴에 해당하는 키의 개수가 50개 미만인 경우, cursor가 0으로 리턴되어 unlink 코드를 타지 않는다.

## 무엇을 어떻게 변경했나요?
우선 match 의 리턴 키가 존재하면 삭제하고, 그 다음에 커서 값을 확인하도록 한다.

## 어떻게 테스트 하셨나요?
npm test
